### PR TITLE
Removendo icones repetidos do painel do mapa

### DIFF
--- a/src/protected/application/lib/modules/QuotasSet/layouts/parts/quotas-set.nav.panel.php
+++ b/src/protected/application/lib/modules/QuotasSet/layouts/parts/quotas-set.nav.panel.php
@@ -1,7 +1,7 @@
 <?php /** @var MapasCulturais\App $app */ ?>
 <li>
     <a href="<?= $app->createUrl('panel', 'cotas-e-politicas') ?>">
-        <span class="icon icon-opportunity"></span>
+        <span class="icon icon-afirmative-politics"></span>
         Políticas de ações afirmativas
     </a>
 </li>

--- a/src/protected/application/themes/BaseV1/assets/css/sass/components/_icons.scss
+++ b/src/protected/application/themes/BaseV1/assets/css/sass/components/_icons.scss
@@ -123,6 +123,16 @@ h1 .icon {
         content: $unicode-accountability;
     }
 }
+.icon-public-consultation {
+    &:before {
+        content: $unicode-public-consultation;
+    }
+}
+.icon-afirmative-politics {
+    &:before {
+        content: $unicode-afirmative-politics;
+    }
+}
 .icon-download {
     &:before {
         content: $unicode-download;

--- a/src/protected/application/themes/BaseV1/assets/css/sass/components/_icons.scss
+++ b/src/protected/application/themes/BaseV1/assets/css/sass/components/_icons.scss
@@ -103,6 +103,26 @@ h1 .icon {
         content: $unicode-opportunity;
     }
 }
+.icon-registrations {
+    &:before {
+        content: $unicode-registrations;
+    }
+}
+.icon-recourses {
+    &:before {
+        content: $unicode-recourses;
+    }
+}
+.icon-counter-arguments {
+    &:before {
+        content: $unicode-counter-arguments;
+    }
+}
+.icon-accountability {
+    &:before {
+        content: $unicode-accountability;
+    }
+}
 .icon-download {
     &:before {
         content: $unicode-download;
@@ -263,3 +283,4 @@ h1 .icon {
         right: -1px;
     }
 }
+

--- a/src/protected/application/themes/BaseV1/assets/css/sass/globals/_variables.scss
+++ b/src/protected/application/themes/BaseV1/assets/css/sass/globals/_variables.scss
@@ -295,6 +295,21 @@ $unicode-search:                "\55"   !default;
 // used on .icon-group on _icons.scss
 $unicode-group:                "\e08b"   !default;
 
+//** Registrations icon
+// used on .icon-registrations on _icons.scss file
+$unicode-registrations: "\e101" !default;
+
+//** Recourse icon
+// used on .icon-recourses on _icons.scss file
+$unicode-recourses: "\e0e6" !default;
+
+//** Counter Arguments icon
+// used on .icon-counter-arguments on _icons.scss file
+$unicode-counter-arguments: "\e104" !default;
+
+//** Accountability icon
+// used on .icon-accountability on _icons.scss file
+$unicode-accountability: "\e0ed" !default;
 
 $unicode-show-advanced-filters:          "\54"   !default;
 

--- a/src/protected/application/themes/BaseV1/assets/css/sass/globals/_variables.scss
+++ b/src/protected/application/themes/BaseV1/assets/css/sass/globals/_variables.scss
@@ -311,6 +311,14 @@ $unicode-counter-arguments: "\e104" !default;
 // used on .icon-accountability on _icons.scss file
 $unicode-accountability: "\e0ed" !default;
 
+//** Public Consultation icon
+// used on .icon-public-consultation on _icons.scss file
+$unicode-public-consultation: "\e0e3" !default;
+
+//** Afirmative Politics icon
+// used on .icon-afirmative-politics on _icons.css file
+$unicode-afirmative-politics: "\e106" !default;
+
 $unicode-show-advanced-filters:          "\54"   !default;
 
 //** Select arrow icon

--- a/src/protected/application/themes/BaseV1/layouts/parts/panel-nav.php
+++ b/src/protected/application/themes/BaseV1/layouts/parts/panel-nav.php
@@ -45,13 +45,13 @@
             <?php $this->applyTemplateHook('nav.panel.opportunities','after'); ?>
 
             <?php $this->applyTemplateHook('nav.panel.registrations','before'); ?>
-            <li><a <?php if($this->template == 'panel/registrations') echo 'class="active"'; ?> href="<?php echo $app->createUrl('panel', 'registrations') ?>"><span class="icon icon-opportunity"></span> <?php \MapasCulturais\i::_e("Minhas Inscrições");?></a></li>
+            <li><a <?php if($this->template == 'panel/registrations') echo 'class="active"'; ?> href="<?php echo $app->createUrl('panel', 'registrations') ?>"><span class="icon icon-registrations"></span> <?php \MapasCulturais\i::_e("Minhas Inscrições");?></a></li>
             <?php $this->applyTemplateHook('nav.panel.registrations','after'); ?>
 
             <?php $this->applyTemplateHook('nav.panel.counterArguments','before'); ?>
             <li>
                 <a <?php if ($this->template == 'panel/counter-arguments') echo 'class="active"'; ?> href="<?= $app->createUrl('panel', 'counterArguments') ?>">
-                    <span class="icon icon-opportunity"></span> Minhas Contrarrazões
+                    <span class="icon icon-counter-arguments"></span> Minhas Contrarrazões
                 </a>
             </li>
             <?php $this->applyTemplateHook('nav.panel.counterArguments','after'); ?>
@@ -59,7 +59,7 @@
             <?php $this->applyTemplateHook('nav.panel.accountability', 'before'); ?>
             <li>
                 <a <?php if ($this->template == 'panel/accountability') echo 'class="active"'; ?> href="<?php echo $app->createUrl('panel', 'accountability') ?>">
-                    <span class="icon icon-opportunity"></span> <?php \MapasCulturais\i::_e("Prestações de Contas"); ?>
+                    <span class="icon icon-accountability"></span> <?php \MapasCulturais\i::_e("Prestações de Contas"); ?>
                 </a>
             </li>
             <?php $this->applyTemplateHook('nav.panel.accountability', 'after'); ?>
@@ -85,17 +85,7 @@
                 </a>
             </li>
             <?php $this->applyTemplateHook('nav.panel.userManagement','after'); ?>
-        <?php endif; ?>
-
-        <?php if($app->user->is('superAdmin')): ?>
-            <?php $this->applyTemplateHook('nav.panel.adminManagement','before'); ?>
-            <li>
-                <a <?php if ($this->template == 'panel/user-management' && isset($_GET['admin'])) echo 'class="active"'; ?> href="<?php echo $app->createUrl('panel', 'userManagement')?>?admin">
-                    <span class="icon icon-group"></span> <?php \MapasCulturais\i::_e("Administradores");?>
-                </a>
-            </li>
-            <?php $this->applyTemplateHook('nav.panel.adminManagement','after'); ?>
-        <?php endif; ?>
+        <?php endif; ?>        
 
         <?php $app->applyHookBoundTo($this, 'panel.menu:after') ?>
     </ul>


### PR DESCRIPTION
### ✅ Descrição do propósito desse Pull Request
foi solicitado que fossem trocados os icones repetidos no painel do mapa e que fosse removido a opção administradores pois não tem serventia 

### 🧭 Referência a Issue
[#660](https://github.com/secultce/mapasculturais-v5/issues/660)

### ❓ O que foi feito para atingir isso?
Inseri novos unicodes no scss para adicionar novos icones. Caso queiram alterar algum dos icones novos segue a referencia de icones disponiveis:
![88b8b9d9-8daf-49cf-ae79-7f1e9d13f18e](https://github.com/user-attachments/assets/a6d14352-c8be-40f0-8af7-c0be10bada69)


### 🏃‍♀️ Tipo de mudança
Marque as opções relevantes:
- [ ] Bug fix (correção de bug)
- [ ] Nova feature (mudança não retrocompatível que adiciona funcionalidade)
- [ ] Mudança de breaking (correção ou feature que faria com que a funcionalidade existente não funcionasse como esperado)
- [ ] Documentação (somente mudanças ou atualizações na documentação)
---

### 🕵️ Como foi testado?
- [ ] Critério de aceitação
- [ ] Testes de software (TDD, BDD, UNITÁRIO, INTEGRAÇÃO, E2E)
---

**Checklist: ✔️**
- [ ] Meu código segue as diretrizes do projeto
- [ ] Eu fiz um code review com minha equipe
- [ ] Eu comentei meu código, especialmente em áreas de difícil entendimento
- [ ] Eu atualizei a documentação correspondente
- [ ] Testes novos e existentes passaram localmente com minhas alterações
---

**Observação:**
