### PR TITLE
Organizando os botões e as badges no painel do mapa

### DIFF
--- a/src/protected/application/lib/modules/CounterArgument/layouts/parts/counter-argument/send-btn.php
+++ b/src/protected/application/lib/modules/CounterArgument/layouts/parts/counter-argument/send-btn.php
@@ -1,7 +1,7 @@
 <?php if ($isCounterArgumentPeriod && !$hasCounterArgument) : ?>
-    <a class="btn btn-primary" data-registration="<?= $registration->id ?>" open-counter-argument>
+    <a class="btn btn-primary registration-panel-button" data-registration="<?= $registration->id ?>" open-counter-argument>
         Abrir Contrarrazão
     </a>
 <?php elseif ($hasCounterArgument) : ?>
-    <span class="badge badge-info">Contrarrazão enviada</span>
+    <span class="badge badge-info registration-panel-badge">Contrarrazão enviada</span>
 <?php endif; ?>

--- a/src/protected/application/themes/BaseV1/layouts/parts/panel-registration.php
+++ b/src/protected/application/themes/BaseV1/layouts/parts/panel-registration.php
@@ -6,6 +6,54 @@ $app = MapasCulturais\App::i();
 $url = $registration->status == Registration::STATUS_DRAFT ? $registration->editUrl : $registration->singleUrl;
 $opportunity = $registration->opportunity;
 ?>
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+    //organizes registration action buttons and badges into rows
+    //add the appropriate classes to your buttons/badges:
+    //.registration-panel-button for buttons
+    //.registration-panel-badge for badges
+    document.querySelectorAll('.registration-actions').forEach(container => {
+
+        const badges = Array.from(
+            container.querySelectorAll('.registration-panel-badge')
+        );
+        const buttons = Array.from(
+            container.querySelectorAll('.registration-panel-button')
+        );
+
+        // Clear container completely
+        container.innerHTML = '';
+
+        // ----- Badges row -----
+        if (badges.length) {
+            const badgeRow = document.createElement('div');
+            badgeRow.className = 'registration-badges-row';
+
+            badgeRow.style.display = 'flex';
+            badgeRow.style.flexWrap = 'wrap';
+            badgeRow.style.gap = '8px';
+            badgeRow.style.marginBottom = '8px';
+
+            badges.forEach(badge => badgeRow.appendChild(badge));
+            container.appendChild(badgeRow);
+        }
+
+        // ----- Buttons row -----
+        if (buttons.length) {
+            const buttonRow = document.createElement('div');
+            buttonRow.className = 'registration-buttons-row';
+
+            buttonRow.style.display = 'flex';
+            buttonRow.style.flexWrap = 'wrap';
+            buttonRow.style.gap = '8px';
+            buttonRow.style.justifyContent = 'flex-end';
+
+            buttons.forEach(button => buttonRow.appendChild(button));
+            container.appendChild(buttonRow);
+        }
+    });
+});
+</script>
 <?php $this->applyTemplateHook('panel-registration', 'before', [$registration]); ?>
 <article class="objeto clearfix">
     <?php $this->applyTemplateHook('panel-registration', 'begin', [$registration]); ?>
@@ -44,8 +92,11 @@ $opportunity = $registration->opportunity;
         <?php endif; ?>
         <?php $this->applyTemplateHook('panel-registration-meta', 'end', [$registration]); ?>
     </div>
-    <?php $this->applyTemplateHook('panel-registration-meta', 'after', [$registration]); ?>
-
+    <div class="registration-actions">
+        <?php $this->applyTemplateHook('panel-registration-meta', 'after', [$registration]); ?>
+    </div>
     <?php $this->applyTemplateHook('panel-registration', 'end', [$registration]); ?>
 </article>
 <?php $this->applyTemplateHook('panel-registration', 'aft, [$registration]er');
+
+

--- a/src/protected/application/themes/BaseV1/layouts/parts/panel-registration.php
+++ b/src/protected/application/themes/BaseV1/layouts/parts/panel-registration.php
@@ -8,10 +8,12 @@ $opportunity = $registration->opportunity;
 ?>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
-    //organizes registration action buttons and badges into rows
-    //add the appropriate classes to your buttons/badges:
-    //.registration-panel-button for buttons
-    //.registration-panel-badge for badges
+    /*
+        organizes registration action buttons and badges into rows
+        add the appropriate classes to your buttons/badges:
+        .resgistration-panel-button for buttons
+        .registration-panel-badge for badges
+    */
     document.querySelectorAll('.registration-actions').forEach(container => {
 
         const badges = Array.from(


### PR DESCRIPTION
### ✅ Descrição do propósito desse Pull Request
Organizando os botões e as badges no painel do mapa

### 🧭 Referência a Issue
https://github.com/secultce/mapasculturais-v5/issues/662

### ❓ O que foi feito para atingir isso?
adicionado javascript que reorganiza os botões e as badges na pagina depois que carrega o DOM, independentemente de qual elemento eles sejam child. Basicamente adicionando as classes registration-panel-button, registration-panel-badge nos botões e nas badges faz com que os mesmos se organizem na tela dessa forma:
<img width="1121" height="612" alt="image" src="https://github.com/user-attachments/assets/3a05c5c1-baad-45ff-ab06-f6b373fee9a9" />

obs: é necessario fazer o merge do plugin do recurso pois tem uma part que vem desse plugin.
### 🏃‍♀️ Tipo de mudança
Marque as opções relevantes:
- [ ] Bug fix (correção de bug)
- [ ] Nova feature (mudança não retrocompatível que adiciona funcionalidade)
- [ ] Mudança de breaking (correção ou feature que faria com que a funcionalidade existente não funcionasse como esperado)
- [ ] Documentação (somente mudanças ou atualizações na documentação)
---

### 🕵️ Como foi testado?
- [ ] Critério de aceitação
- [ ] Testes de software (TDD, BDD, UNITÁRIO, INTEGRAÇÃO, E2E)
---

**Checklist: ✔️**
- [ ] Meu código segue as diretrizes do projeto
- [ ] Eu fiz um code review com minha equipe
- [ ] Eu comentei meu código, especialmente em áreas de difícil entendimento
- [ ] Eu atualizei a documentação correspondente
- [ ] Testes novos e existentes passaram localmente com minhas alterações
---

**Observação:**
