### PR TITLE
Fix/event importer overnight occurrence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Todas as mudanças notáveis no projeto serão documentadas neste arquivo.
 O formato é baseado no [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/)
 e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Corrigido
+- Corrige a validação de ocorrências do importador de eventos para considerar data e hora ao importar eventos que terminam no dia seguinte.
+
 ## [5.12.0] - 2026-03-17
 ### Adicionado
 - Contrar

--- a/src/protected/application/lib/modules/EventImporter/Controller.php
+++ b/src/protected/application/lib/modules/EventImporter/Controller.php
@@ -504,12 +504,6 @@ class Controller extends \MapasCulturais\Controller
                if($ends_at != $value['ENDS_AT']){
                   $errors[$key+1][] = i::__("A coluna Hora final é inválida. O formato esperado é HH:MM Ex.: 12:00");
                }
-               
-               
-               if((new DateTime($value['STARTS_AT'])) > (new DateTime($value['ENDS_AT']))){
-                  $errors[$key+1][] = i::__("A data inicial é maior que a data final.");
-               }
-
                // Valida a data inicial
                if (empty($value['STARTS_ON']) || $value['STARTS_ON'] == "") {
                   $errors[$key+1][] = i::__("A Coluna Data inícial Está vazia");
@@ -529,6 +523,12 @@ class Controller extends \MapasCulturais\Controller
                   $ends_on = $this->formatDate($value['ENDS_ON'], "Y-m-d");
                   if ($ends_on != $value['ENDS_ON']) {
                      $errors[$key+1][] = i::__("A coluna data final é inválida. O formato esperado é DD/MM/YYYY Ex.: 01/01/2022");
+                  }
+               }
+
+               if(!empty($value['STARTS_ON']) && !empty($value['STARTS_AT']) && !empty($value['ENDS_AT'])){
+                  if($this->getOccurrenceStartDateTime($value) > $this->getOccurrenceEndDateTime($value)){
+                     $errors[$key+1][] = i::__("A data inicial é maior que a data final.");
                   }
                }
 
@@ -746,11 +746,7 @@ class Controller extends \MapasCulturais\Controller
          $ocurrence = new EventOccurrence();    
    
          $duration = function() use ($value){
-            $start = $this->formatDate($value['STARTS_AT']);
-            $stop = $this->formatDate($value['ENDS_AT']);
-            $diferenca = strtotime($stop) - strtotime($start);
-   
-            return ($diferenca / 60);
+            return $this->getOccurrenceDurationInMinutes($value);
          };
    
          $collum = $this->checkCollum($value['SPACE']);
@@ -1011,6 +1007,26 @@ class Controller extends \MapasCulturais\Controller
    public function error($message)
    {
       throw new Exception(i::__($message));
+   }
+
+   public function getOccurrenceStartDateTime($value)
+   {
+      return new DateTime("{$value['STARTS_ON']} {$value['STARTS_AT']}");
+   }
+
+   public function getOccurrenceEndDateTime($value)
+   {
+      $ends_on = !empty($value['ENDS_ON']) ? $value['ENDS_ON'] : $value['STARTS_ON'];
+
+      return new DateTime("{$ends_on} {$value['ENDS_AT']}");
+   }
+
+   public function getOccurrenceDurationInMinutes($value)
+   {
+      $starts_at = $this->getOccurrenceStartDateTime($value);
+      $ends_at = $this->getOccurrenceEndDateTime($value);
+
+      return (int) (($ends_at->getTimestamp() - $starts_at->getTimestamp()) / 60);
    }
 
    public function formatDate($date, $formatOut = "Y-m-d H:i")

--- a/tests/EventImporterControllerTest.php
+++ b/tests/EventImporterControllerTest.php
@@ -1,0 +1,38 @@
+<?php
+require_once __DIR__ . '/bootstrap.php';
+
+use EventImporter\Controller;
+
+class EventImporterControllerTest extends \PHPUnit\Framework\TestCase
+{
+    function testOccurrenceEndDateTimeUsesEndsOnWhenProvided()
+    {
+        $controller = Controller::i('eventimporter');
+
+        $value = [
+            'STARTS_ON' => '2026-06-12',
+            'ENDS_ON' => '2026-06-13',
+            'STARTS_AT' => '18:00',
+            'ENDS_AT' => '01:00',
+        ];
+
+        $this->assertEquals(
+            '2026-06-13 01:00',
+            $controller->getOccurrenceEndDateTime($value)->format('Y-m-d H:i')
+        );
+    }
+
+    function testOccurrenceDurationConsidersEndsOn()
+    {
+        $controller = Controller::i('eventimporter');
+
+        $value = [
+            'STARTS_ON' => '2026-06-12',
+            'ENDS_ON' => '2026-06-13',
+            'STARTS_AT' => '18:00',
+            'ENDS_AT' => '01:00',
+        ];
+
+        $this->assertEquals(420, $controller->getOccurrenceDurationInMinutes($value));
+    }
+}


### PR DESCRIPTION
## Resumo

Corrige a validação de horários no importador de eventos para considerar a data junto com a hora ao validar ocorrências.

Antes, um evento importado com início em `12/06 18:00` e fim em `13/06 01:00` era rejeitado com a mensagem “A data inicial é maior que a data final”, porque o importador comparava apenas `18:00 > 01:00`.

## O que foi alterado

- A validação de ocorrência agora compara `DATA INICIAL + HORA INICIAL` com `DATA FINAL + HORA FINAL`.
- Quando `DATA FINAL` está preenchida, ela passa a ser usada para montar o horário final da ocorrência.
- O cálculo de duração da ocorrência também passa a considerar a data final, evitando duração negativa em eventos que terminam no dia seguinte.
- Foi adicionado teste cobrindo o caso `12/06 18:00` até `13/06 01:00`.
- `CHANGELOG.md` atualizado em `Unreleased`.