### PR TITLE
ajusta envio do parecer

### DIFF
--- a/src/protected/application/lib/MapasCulturais/Controllers/Registration.php
+++ b/src/protected/application/lib/MapasCulturais/Controllers/Registration.php
@@ -434,7 +434,9 @@ class Registration extends EntityController {
     }
 
     function POST_saveEvaluation(){
+        $this->requireAuthentication();
         $registration = $this->getRequestedEntity();
+        $allow_reopen = filter_var($this->postData['reopen'] ?? false, FILTER_VALIDATE_BOOLEAN);
         if(isset($this->postData['uid'])){
             $user = App::i()->repo('User')->find($this->postData['uid']);
         } else {
@@ -450,8 +452,17 @@ class Registration extends EntityController {
                 $status = Entities\RegistrationEvaluation::STATUS_EVALUATED;
             } else if ($this->urlData['status'] === 'draft') {
                 $evaluation = $registration->getUserEvaluation($user);
-                if (!$evaluation || !$evaluation->canUser('modify', $user)) {
-                    $this->errorJson("User {$user->id} is trying to modify evaluation {$evaluation->id}.", 401);
+                $evaluation_user = $user ?? App::i()->user;
+                $can_save_draft = $evaluation
+                    ? $evaluation->canUser('modify', $evaluation_user)
+                    : $registration->canUser('evaluate', $evaluation_user);
+
+                if (!$can_save_draft) {
+                    $evaluation_id = $evaluation ? $evaluation->id : 'new';
+                    $this->errorJson(
+                        "User {$evaluation_user->id} is trying to modify evaluation {$evaluation_id}.",
+                        401
+                    );
                     return;
                 }
                 $status = Entities\RegistrationEvaluation::STATUS_DRAFT;
@@ -459,7 +470,12 @@ class Registration extends EntityController {
                 $this->errorJson("Invalid evaluation status {$this->urlData["status"]} received from client.", 400);
                 return;
             }
-            $evaluation = $registration->saveUserEvaluation(($this->postData['data'] ?? []), $user, $status);
+            $evaluation = $registration->saveUserEvaluation(
+                ($this->postData['data'] ?? []),
+                $user,
+                $status,
+                $allow_reopen
+            );
         } else {
             $evaluation = $registration->saveUserEvaluation($this->postData['data'], $user);
         }
@@ -493,6 +509,7 @@ class Registration extends EntityController {
     }
 
     function POST_saveEvaluationAndChangeStatus(){
+        $this->requireAuthentication();
         $registration = $this->getRequestedEntity();
 
         if(isset($this->postData['uid'])){

--- a/src/protected/application/lib/MapasCulturais/Entities/Registration.php
+++ b/src/protected/application/lib/MapasCulturais/Entities/Registration.php
@@ -1369,7 +1369,75 @@ class Registration extends \MapasCulturais\Entity
         $evaluation->save(true);
     }
 
-    function saveUserEvaluation(array $data, User $user = null, $evaluation_status = null){
+    /**
+     * Runs an evaluation write while holding a lock on the registration row.
+     *
+     * The registration is the stable parent shared by all concurrent requests,
+     * including the first request, when no RegistrationEvaluation exists yet.
+     */
+    public function withOpinionSubmissionLock(callable $callback) {
+        $connection = App::i()->em->getConnection();
+        $owns_transaction = !$connection->isTransactionActive();
+
+        if ($owns_transaction) {
+            $connection->beginTransaction();
+        }
+
+        try {
+            // The migration takes the exclusive form of this lock before its
+            // table locks. Writers take the shared form before any row lock,
+            // so deploying the cleanup while requests are active cannot invert
+            // the lock order.
+            $connection->executeQuery(
+                "SELECT pg_advisory_xact_lock_shared(hashtext('MapasCulturais:opinion-submission:migration'))"
+            );
+            $connection->executeQuery(
+                'SELECT id FROM registration WHERE id = ? FOR UPDATE',
+                [$this->id]
+            );
+
+            $result = $callback();
+            if ($owns_transaction) {
+                $connection->commit();
+            }
+
+            return $result;
+        } catch (\Throwable $exception) {
+            if ($owns_transaction && $connection->isTransactionActive()) {
+                $connection->rollBack();
+            }
+
+            throw $exception;
+        }
+    }
+
+    /**
+     * Atomically creates the empty evaluation used when a valuer first opens it.
+     */
+    function initializeUserEvaluation(User $user = null, bool $only_one_per_registration = false) {
+        $app = App::i();
+        $user = $user ?? $app->user;
+
+        return $this->withOpinionSubmissionLock(function () use ($app, $user, $only_one_per_registration) {
+            $evaluation = $only_one_per_registration
+                ? $app->repo('RegistrationEvaluation')->findOneBy(['registration' => $this])
+                : $this->getUserEvaluation($user);
+
+            if ($evaluation) {
+                $app->em->refresh($evaluation);
+                return $evaluation;
+            }
+
+            $evaluation = new RegistrationEvaluation;
+            $evaluation->user = $user;
+            $evaluation->registration = $this;
+            $evaluation->save(true);
+
+            return $evaluation;
+        });
+    }
+
+    function saveUserEvaluation(array $data, User $user = null, $evaluation_status = null, bool $allow_reopen = false){
         $app = App::i();
 
         if ($this->opportunity->canUser('@control') && !empty($data['uid'])) {
@@ -1378,17 +1446,58 @@ class Registration extends \MapasCulturais\Entity
             $user = $user ?? $app->user;
         }
 
-        $evaluation = $this->getUserEvaluation($user);
-        
-        if(!$evaluation){
-            $evaluation = new RegistrationEvaluation;
-            $evaluation->user = $user;
-            $evaluation->registration = $this;
-        }
+        return $this->withOpinionSubmissionLock(function () use ($app, $data, $user, $evaluation_status, $allow_reopen) {
+            // Accountability has one technical opinion for the whole
+            // registration. Other evaluation methods keep one per valuer.
+            $only_one_per_registration = (bool) $this->opportunity->isAccountabilityPhase;
+            $evaluation = $only_one_per_registration
+                ? $app->repo('RegistrationEvaluation')->findOneBy(['registration' => $this])
+                : $this->getUserEvaluation($user);
 
-        $this->saveEvaluation($evaluation, $data, $evaluation_status);
+            if ($evaluation) {
+                // The entity may have been loaded before waiting for the row lock.
+                $app->em->refresh($evaluation);
 
-        return $evaluation;
+                // Entity::save() normally performs this check. No-op returns
+                // must do it explicitly or an unauthorized caller could obtain
+                // the serialized evaluation (including its private data).
+                $evaluation->checkPermission('modify');
+
+                $is_late_draft = $evaluation_status === RegistrationEvaluation::STATUS_DRAFT
+                    && $evaluation->status > RegistrationEvaluation::STATUS_DRAFT;
+                $is_sent = $evaluation->status >= RegistrationEvaluation::STATUS_SENT;
+
+                // Once evaluations are sent to the opportunity owner, no stale
+                // or repeated write may change their status or contents.
+                if ($is_sent) {
+                    return $evaluation;
+                }
+
+                $is_identical_submission = !is_null($evaluation_status)
+                    && (int) $evaluation->status === (int) $evaluation_status
+                    && (array) $evaluation->evaluationData == $data;
+
+                // Repeated final submissions and autosaves are idempotent: do
+                // not create duplicate revisions or run consolidation hooks.
+                if ($is_identical_submission) {
+                    return $evaluation;
+                }
+
+                // A delayed autosave must not overwrite a completed evaluation.
+                // Reopening an evaluated opinion is a separate explicit action.
+                if ($is_late_draft && !$allow_reopen) {
+                    return $evaluation;
+                }
+            } else {
+                $evaluation = new RegistrationEvaluation;
+                $evaluation->user = $user;
+                $evaluation->registration = $this;
+            }
+
+            $this->saveEvaluation($evaluation, $data, $evaluation_status);
+
+            return $evaluation;
+        });
     }
 
     public function evaluationUserChangeStatus($user, Registration $registration, $status) {

--- a/src/protected/application/lib/MapasCulturais/Entities/RegistrationEvaluation.php
+++ b/src/protected/application/lib/MapasCulturais/Entities/RegistrationEvaluation.php
@@ -20,7 +20,15 @@ use MapasCulturais\App;
  * @property User $user
  * @property integer $status
  *
- * @ORM\Table(name="registration_evaluation")
+ * @ORM\Table(
+ *     name="registration_evaluation",
+ *     uniqueConstraints={
+ *         @ORM\UniqueConstraint(
+ *             name="registration_evaluation_registration_user_unique",
+ *             columns={"registration_id", "user_id"}
+ *         )
+ *     }
+ * )
  * @ORM\Entity
  * @ORM\entity(repositoryClass="MapasCulturais\Repositories\RegistrationEvaluation")
  * @ORM\HasLifecycleCallbacks
@@ -97,12 +105,41 @@ class RegistrationEvaluation extends \MapasCulturais\Entity {
     protected $status = self::STATUS_DRAFT;
 
     function save($flush = false){
+        // All persisted evaluation writes use the same lock order, including
+        // legacy bulk-send/reopen flows that save this entity directly.
+        if ($flush && $this->registration && $this->registration->id) {
+            return $this->registration->withOpinionSubmissionLock(function () use ($flush) {
+                return $this->saveEvaluationEntity($flush);
+            });
+        }
+
+        return $this->saveEvaluationEntity($flush);
+    }
+
+    private function saveEvaluationEntity($flush) {
         parent::save($flush);
         $app = App::i();
         $opportunity = $this->registration->opportunity;
         
         // cache utilizado pelo endpoint findEvaluations
         $app->mscache->delete("api:opportunity:{$opportunity->id}:evaluations");
+    }
+
+    function delete($flush = false) {
+        // Removing a valuer deletes their evaluations and postRemove then
+        // reconsolidates the registration. Keep the same parent-before-child
+        // lock order used by saves to avoid a save/delete deadlock.
+        if ($flush && $this->registration && $this->registration->id) {
+            return $this->registration->withOpinionSubmissionLock(function () use ($flush) {
+                return $this->deleteEvaluationEntity($flush);
+            });
+        }
+
+        return $this->deleteEvaluationEntity($flush);
+    }
+
+    private function deleteEvaluationEntity($flush) {
+        return parent::delete($flush);
     }
     
     function getEvaluationData(){

--- a/src/protected/application/lib/modules/Diligence/Controllers/Controller.php
+++ b/src/protected/application/lib/modules/Diligence/Controllers/Controller.php
@@ -520,16 +520,27 @@ class Controller extends \MapasCulturais\Controller implements NotificationInter
     private function createOrUpdateOpinion($data, $publish)
     {
         $registrationId = (int)$data["registrationId"];
-        $registration = App::i()->repo('Registration')->find($registrationId);
-        $opinion = App::i()->repo(OpinionEntity::class)->findOneBy(['registration' => $registration]);
+        $app = App::i();
+        $registration = $app->repo('Registration')->find($registrationId);
 
         $registration->checkPermission('evaluate');
 
-        if ($opinion) {
-            $opinion->update($data["opinion"], $publish);
-        } else {
-            $opinionEntity = new OpinionEntity();
-            $opinionEntity->create($data["opinion"], $registration, $publish);
-        }
+        $registration->withOpinionSubmissionLock(function () use ($app, $registration, $data, $publish) {
+            $opinion = $app->repo(OpinionEntity::class)->findOneBy(['registration' => $registration]);
+
+            if ($opinion) {
+                // It may have been loaded before this request acquired the lock.
+                $app->em->refresh($opinion);
+
+                // Publication is irreversible in the UI. Repeated publication
+                // and a delayed draft save are therefore idempotent no-ops.
+                if ($opinion->status !== OpinionEntity::STATUS_ENABLED) {
+                    $opinion->update($data["opinion"], $publish);
+                }
+            } else {
+                $opinion = new OpinionEntity();
+                $opinion->create($data["opinion"], $registration, $publish);
+            }
+        });
     }
 }

--- a/src/protected/application/lib/modules/Diligence/Entities/Opinion.php
+++ b/src/protected/application/lib/modules/Diligence/Entities/Opinion.php
@@ -10,7 +10,15 @@ use MapasCulturais\Traits;
 /**
  * Opinion 
  * 
- * @ORM\Table(name="accountability_opinion")
+ * @ORM\Table(
+ *     name="accountability_opinion",
+ *     uniqueConstraints={
+ *         @ORM\UniqueConstraint(
+ *             name="accountability_opinion_registration_unique",
+ *             columns={"registration_id"}
+ *         )
+ *     }
+ * )
  * @ORM\Entity
  * @ORM\entity(repositoryClass="MapasCulturais\Repository")
  */

--- a/src/protected/application/lib/modules/Diligence/assets/js/diligence/diligence.js
+++ b/src/protected/application/lib/modules/Diligence/assets/js/diligence/diligence.js
@@ -8,6 +8,10 @@ let objSendDiligence = {
     createTimestamp: moment().format("YYYY-MM-DD")
 }
 
+let opinionRequest = null;
+let opinionPublished = false;
+let opinionConfirmationPending = false;
+
 $(document).ready(function () {
     $("#paragraph_value_project").hide();
 
@@ -93,18 +97,40 @@ $(document).ready(function () {
         saveAuthorizedProject('value_project_diligence', e.target.value)
     });
 
-    $('.save-opinion-accountability-btn').on('click', function () {
+    $('.save-opinion-accountability-btn').on('click', function (event) {
+        event.preventDefault();
+
+        if (opinionRequest || opinionPublished || opinionConfirmationPending) {
+            return;
+        }
+
         saveOrPublishOpinion('save')
     })
 
-    $('.publish-opinion-accountability-btn').on('click', function () {
+    $('.publish-opinion-accountability-btn').on('click', function (event) {
+        event.preventDefault();
+
+        if (opinionRequest || opinionPublished || opinionConfirmationPending) {
+            return;
+        }
+
+        opinionConfirmationPending = true;
+        setOpinionActionsBusy(true);
+
         McMessages.messageConfirm(
             "Deseja publicar o parecer?",
             "Essa ação não poderá ser desfeita.",
         ).then(res => {
+            opinionConfirmationPending = false;
+
             if (res.isConfirmed) {
                 saveOrPublishOpinion('publish')
+            } else {
+                setOpinionActionsBusy(false);
             }
+        }, () => {
+            opinionConfirmationPending = false;
+            setOpinionActionsBusy(false);
         })
     })
 });
@@ -390,26 +416,65 @@ function trashDraftDiligence(idDiligence, titleQuestion, textTrash, titleCancel,
     })
 }
 
+function setOpinionActionsBusy(busy) {
+    $('.save-opinion-accountability-btn, .publish-opinion-accountability-btn')
+        .prop('disabled', busy)
+        .toggleClass('disabled', busy)
+        .attr('aria-busy', busy ? 'true' : 'false');
+    $('.opinion-form #opinion-accountability').prop('disabled', busy);
+    $('.opinion-form').attr('aria-busy', busy ? 'true' : 'false');
+}
+
 function saveOrPublishOpinion(action) {
-    $.ajax({
+    if (opinionRequest || opinionPublished) {
+        return opinionRequest;
+    }
+
+    setOpinionActionsBusy(true);
+
+    const request = $.ajax({
         type: "POST",
         url: MapasCulturais.createUrl('diligence', `${action}Opinion`),
         data: {
             opinion: $('.opinion-form #opinion-accountability').val(),
             registrationId: MapasCulturais.entity.id,
         },
-        dataType: "json",
-        success(res) {
-            MapasCulturais.Messages.success(res.message)
+        dataType: "json"
+    });
 
-            if (action === 'publish') {
-                setTimeout(() => {
-                    location.reload()
-                }, 1500)
-            }
-        },
-        error(err) {
-            MapasCulturais.Messages.error(err.responseJSON.message);
+    opinionRequest = request;
+
+    request.done(function () {
+        if (action === 'publish') {
+            opinionPublished = true;
+            setTimeout(() => {
+                location.reload()
+            }, 1500)
         }
-    })
+    });
+
+    // Unlock before reporting an error so an unexpected error payload cannot
+    // leave the controls permanently disabled.
+    request.always(function () {
+        if (opinionRequest === request) {
+            opinionRequest = null;
+        }
+
+        if (!opinionPublished) {
+            setOpinionActionsBusy(false);
+        }
+    });
+
+    request.done(function (res) {
+        MapasCulturais.Messages.success(res.message)
+    });
+
+    request.fail(function (err) {
+        const message = err.responseJSON && err.responseJSON.message
+            ? err.responseJSON.message
+            : 'Ocorreu um erro ao salvar o parecer';
+        MapasCulturais.Messages.error(message);
+    });
+
+    return request;
 }

--- a/src/protected/application/lib/modules/Diligence/layouts/parts/diligence/tabs-parent.php
+++ b/src/protected/application/lib/modules/Diligence/layouts/parts/diligence/tabs-parent.php
@@ -145,8 +145,8 @@ $this->part('diligence/ul-buttons', ['entity' => $registration, 'sendEvaluation'
             <div class="opinion-form d-none">
                 <textarea id="opinion-accountability" rows="10" class="textarea-opinion" placeholder="Digite seu parecer aqui..."><?= $opinion ? $opinion->opinion : '' ?></textarea>
                 <div>
-                    <button class="save-opinion-accountability-btn">Salvar</button>
-                    <button class="publish-opinion-accountability-btn">Publicar</button>
+                    <button type="button" class="save-opinion-accountability-btn">Salvar</button>
+                    <button type="button" class="publish-opinion-accountability-btn">Publicar</button>
                 </div>
             </div>
         <?php else : ?>

--- a/src/protected/application/lib/modules/OpportunityAccountability/Module.php
+++ b/src/protected/application/lib/modules/OpportunityAccountability/Module.php
@@ -669,15 +669,9 @@ class Module extends \MapasCulturais\Module
             $project = $this->requestedEntity;
             if ($project && $project->isAccountability && $project->canUser('evaluate')) {
                 if ($accountability = $project->registration->accountabilityPhase ?? null) {
-                    $criteria = [
-                        'registration' => $accountability
-                    ];
-                    if (!$app->repo('RegistrationEvaluation')->findOneBy($criteria)) {
-                        $evaluation = new RegistrationEvaluation;
-                        $evaluation->user = $app->user;
-                        $evaluation->registration = $accountability;
-                        $evaluation->save(true);
-                    }
+                    // Accountability has a single technical opinion per
+                    // registration, regardless of who opens the project.
+                    $accountability->initializeUserEvaluation($app->user, true);
                 }
             }
          });

--- a/src/protected/application/lib/modules/OpportunityAccountability/assets/js/ng.evaluationMethod.accountability.js
+++ b/src/protected/application/lib/modules/OpportunityAccountability/assets/js/ng.evaluationMethod.accountability.js
@@ -84,7 +84,7 @@
         return {
             reopen: function (registrationId, evaluationData, uid) {
                 var url = MapasCulturais.createUrl("registration", "saveEvaluation", {id: registrationId, status: "draft"});
-                return $http.post(url, {data: evaluationData, uid});
+                return $http.post(url, {data: evaluationData, uid, reopen: true});
             },
 
             save: function (registrationId, evaluationData, uid) {
@@ -164,28 +164,75 @@
             return;
         });
 
+        $scope.sending = false;
         $scope.obsTimeOut = null;
+
+        var autoSaveRequest = null;
+        var autoSaveQueued = false;
+        var evaluationEditor = null;
+
+        function clearObsAutoSave() {
+            clearTimeout($scope.obsTimeOut);
+            $scope.obsTimeOut = null;
+        }
+
+        function autoSaveEvaluation() {
+            if ($scope.sending) {
+                autoSaveQueued = false;
+                return null;
+            }
+
+            if (autoSaveRequest) {
+                autoSaveQueued = true;
+                return autoSaveRequest;
+            }
+
+            autoSaveQueued = false;
+
+            var request = AccountabilityEvaluationService.autoSave(registrationId, $scope.evaluationData, MapasCulturais.evaluation.user);
+            autoSaveRequest = request;
+
+            request.success(function () {
+                MapasCulturais.Messages.success('Salvo');
+            }).error(function (data) {
+                MapasCulturais.Messages.error(data.data[0]);
+            });
+
+            request.finally(function () {
+                if (autoSaveRequest === request) {
+                    autoSaveRequest = null;
+                }
+
+                if (autoSaveQueued && !$scope.sending) {
+                    autoSaveEvaluation();
+                }
+            });
+
+            return request;
+        }
+
+        $scope.$watch('sending', function (sending) {
+            if (evaluationEditor) {
+                evaluationEditor.enable(!sending);
+            }
+        });
+
         $scope.$watchGroup(['evaluationData.obs'], function(new_val, old_val) {
-            if(new_val != old_val){
-                clearTimeout($scope.obsTimeOut)               
-                $scope.obsTimeOut = setTimeout(() => {
-                    AccountabilityEvaluationService.autoSave(registrationId, $scope.evaluationData, MapasCulturais.evaluation.user).success(function () {
-                        MapasCulturais.Messages.success('Salvo');
-                    }).error(function (data) {
-                        MapasCulturais.Messages.error(data.data[0]);
-                    });
+            if(new_val != old_val && !$scope.sending){
+                clearObsAutoSave();
+                $scope.obsTimeOut = setTimeout(function () {
+                    $scope.obsTimeOut = null;
+                    autoSaveEvaluation();
                 }, 10000);
             }
-            
         });
 
         $scope.$watchGroup(['evaluationData.result'], function(new_val, old_val) {
-            if(new_val != old_val){
-                AccountabilityEvaluationService.autoSave(registrationId, $scope.evaluationData, MapasCulturais.evaluation.user).success(function () {
-                    MapasCulturais.Messages.success('Salvo');
-                }).error(function (data) {
-                    MapasCulturais.Messages.error(data.data[0]);
-                });
+            if(new_val != old_val && !$scope.sending){
+                // The result autosave already contains the current observation, so
+                // a pending observation autosave would only repeat the same write.
+                clearObsAutoSave();
+                autoSaveEvaluation();
             }
         });
 
@@ -267,20 +314,55 @@
         };
 
         $scope.sendEvaluation = function () {
+            if ($scope.sending) {
+                return;
+            }
+
             if (!confirm("Você tem certeza que deseja finalizer o parecer técnico?\n\nApós a finalização não será mais possível modificar o parecer.")) {
                 return;
             }
 
-            AccountabilityEvaluationService.send(registrationId, $scope.evaluationData, MapasCulturais.evaluation.user).success(function () {
-                MapasCulturais.Messages.success('Salvo');
-                setTimeout(function () {
-                    location.reload();
+            var finalEvaluationData = angular.copy($scope.evaluationData);
+            $scope.sending = true;
+            clearObsAutoSave();
+            autoSaveQueued = false;
+
+            var pendingAutoSave = autoSaveRequest;
+            var sendRequestStarted = false;
+
+            function sendEvaluationRequest() {
+                if (sendRequestStarted) {
                     return;
-                }, 500);
-            }).error(function (data) {
-                MapasCulturais.Messages.error(data.data[0]);
-            });
+                }
+
+                sendRequestStarted = true;
+
+                AccountabilityEvaluationService.send(registrationId, finalEvaluationData, MapasCulturais.evaluation.user).success(function () {
+                    setTimeout(function () {
+                        location.reload();
+                        return;
+                    }, 500);
+                    MapasCulturais.Messages.success('Salvo');
+                }).error(function (data) {
+                    $scope.sending = false;
+                    MapasCulturais.Messages.error(data.data[0]);
+                });
+            }
+
+            // Never let a draft autosave finish after the final submission. A
+            // scheduled autosave is cancelled above and an in-flight one is
+            // allowed to settle before the evaluated request is sent.
+            if (pendingAutoSave) {
+                pendingAutoSave.then(sendEvaluationRequest, sendEvaluationRequest);
+            } else {
+                sendEvaluationRequest();
+            }
         }
+
+        $scope.$on('$destroy', function () {
+            clearObsAutoSave();
+            autoSaveQueued = false;
+        });
 
         $scope.reopenAccountability = function () {
 
@@ -308,7 +390,7 @@
                 return;
             }
             
-            var editor = new Quill(container, {
+            evaluationEditor = new Quill(container, {
                 modules: { 
                     toolbar: [
                         ['bold', 'italic', 'underline', 'strike'],
@@ -318,9 +400,10 @@
                 },
                 theme: 'snow'
             });
-            
-            editor.on('text-change', function(){
-                $scope.evaluationData.obs = editor.root.innerHTML;
+
+            evaluationEditor.enable(!$scope.sending);
+            evaluationEditor.on('text-change', function(){
+                $scope.evaluationData.obs = evaluationEditor.root.innerHTML;
                 $scope.$apply();
             });
        },1000);

--- a/src/protected/application/lib/modules/OpportunityAccountability/layouts/parts/accountability--evaluation-form.php
+++ b/src/protected/application/lib/modules/OpportunityAccountability/layouts/parts/accountability--evaluation-form.php
@@ -13,17 +13,17 @@ $disable = ($evaluation->status == RegistrationEvaluation::STATUS_EVALUATED) ? "
         <?php if(!$disable && $registration->canUser('evaluate')){?>
         <h4> <?php i::_e('Resultado') ?> </h4>
             <label>
-                <input type="radio" ng-model="evaluationData.result" value="10" <?=$disable?>>
+                <input type="radio" ng-model="evaluationData.result" value="10" ng-disabled="sending" <?=$disable?>>
                 <?php i::_e('Aprovado') ?>
             </label>
 
             <label>
-                <input type="radio" ng-model="evaluationData.result" value="8" <?=$disable?>>
+                <input type="radio" ng-model="evaluationData.result" value="8" ng-disabled="sending" <?=$disable?>>
                 <?php i::_e('Aprovado com ressalvas') ?>
             </label>
 
             <label>
-                <input type="radio" ng-model="evaluationData.result" value="3" <?=$disable?>>
+                <input type="radio" ng-model="evaluationData.result" value="3" ng-disabled="sending" <?=$disable?>>
                 <?php i::_e('Não aprovado') ?>
             </label>
         <?php } ?>
@@ -47,13 +47,13 @@ $disable = ($evaluation->status == RegistrationEvaluation::STATUS_EVALUATED) ? "
         <?php if (!empty($disable)) { ?>
             <span><?php i::_e("Parecer técnico enviado com status") ?> <b>{{resultString}}</b></span>
             <?php if(!$registration->isPublishedResult){?>
-                <button class="btn btn-primary align-right" ng-click="reopenAccountability()"><?php i::_e("Reabrir prestação de contas") ?></button>
+                <button type="button" class="btn btn-primary align-right" ng-click="reopenAccountability()"><?php i::_e("Reabrir prestação de contas") ?></button>
             <?php } else { ?>
-                <button class="btn btn-success align-right"><?php i::_e("Resultado já publicado") ?></button>
+                <button type="button" class="btn btn-success align-right"><?php i::_e("Resultado já publicado") ?></button>
             <?php }?>
             <div class="evaluation-obs" ng-bind-html="::evaluationData.obs"></div>
         <?php } else { ?>
-            <button class="btn btn-primary align-right" ng-click="sendEvaluation()"><?php i::_e("Finalizar e enviar o parecer técnico") ?></button>
+            <button type="button" class="btn btn-primary align-right" ng-click="sendEvaluation()" ng-disabled="sending" ng-attr-aria-busy="{{sending ? 'true' : 'false'}}"><?php i::_e("Finalizar e enviar o parecer técnico") ?></button>
         <?php } ?>
     <?php } ?>
     </section>

--- a/src/protected/application/themes/BaseV1/assets/js/evaluations.js
+++ b/src/protected/application/themes/BaseV1/assets/js/evaluations.js
@@ -5,40 +5,38 @@ $(function(){
     var $form = $formContainer.find('form');
     var $list = $('#registrations-list-container');
     var $header = $('#main-header');
-    $(window).scroll(function(){
-        var top = parseInt($header.css('top'));
-        /* $formContainer.css('margin-top', top);
-        $list.css('margin-top', top); */
-    });
-    
-    $formContainer.find('.js-evaluation-submit').on('click', function (e) {
-        e.preventDefault();
+    var __onChangeTimeout = null;
+    var autoSaveRequest = null;
+    var autoSaveQueued = false;
+    var autoSaveCompletionCallbacks = [];
+    var evaluationSubmitRequest = null;
+    var evaluationSubmissionInProgress = false;
+    var evaluationControlStates = null;
 
-        var $button = $(this);
-        var url = MapasCulturais.createUrl('registration', 'saveEvaluation', {
-            '0': MapasCulturais.request.id,
-            'status': 'evaluated'
-        });
-
-        var isValid = true;
-        $('.bonus-select').each(function () {
-            var $select = $(this);
-            var value = $select.val();
-
-            if (value==="?") { 
-
-                    isValid = false;
-                    MapasCulturais.Messages.error('Por favor, selecione uma opção válida em todos os campos de bônus.');
-                    $select.focus();
-                    return false; 
-                }
-
-        });
-
-        if (!isValid) {
-            return;
+    function setEvaluationSubmitBusy($button, busy) {
+        if (busy && !evaluationControlStates) {
+            evaluationControlStates = [];
+            $form.find(':input').each(function () {
+                evaluationControlStates.push({
+                    element: this,
+                    disabled: this.disabled
+                });
+                this.disabled = true;
+            });
+        } else if (!busy && evaluationControlStates) {
+            $.each(evaluationControlStates, function (index, state) {
+                state.element.disabled = state.disabled;
+            });
+            evaluationControlStates = null;
         }
 
+        $button.prop('disabled', busy)
+            .toggleClass('is-disabled', busy)
+            .attr('aria-busy', busy ? 'true' : 'false');
+        $form.attr('aria-busy', busy ? 'true' : 'false');
+    }
+
+    function getEvaluationData() {
         var data = $form.serializeArray();
 
         $('.bonus-select').each(function () {
@@ -58,9 +56,74 @@ $(function(){
             }
         });
 
-        $.post(url, { data: dataObject }, function (r) {
-            MapasCulturais.Messages.success(labels.saveMessage);
+        return dataObject;
+    }
 
+    function autoSaveEvaluation() {
+        if (evaluationSubmissionInProgress) {
+            autoSaveQueued = false;
+            return;
+        }
+
+        if (autoSaveRequest) {
+            autoSaveQueued = true;
+            return;
+        }
+
+        autoSaveQueued = false;
+
+        var data = $form.serialize();
+        var url = MapasCulturais.createUrl('registration', 'saveEvaluation', {'0': MapasCulturais.request.id, 'status': 'evaluated'});
+        var request = $.post(url, data);
+
+        autoSaveRequest = request;
+        request.always(function () {
+            var completionCallbacks = autoSaveCompletionCallbacks;
+            autoSaveCompletionCallbacks = [];
+
+            if (autoSaveRequest === request) {
+                autoSaveRequest = null;
+            }
+
+            if (autoSaveQueued && !evaluationSubmissionInProgress) {
+                autoSaveEvaluation();
+            }
+
+            $.each(completionCallbacks, function (index, callback) {
+                callback();
+            });
+        });
+
+        request.done(function () {
+            MapasCulturais.Messages.success(labels.saveMessage);
+        });
+    }
+
+    function submitEvaluation($button, url, dataObject) {
+        if (evaluationSubmitRequest) {
+            return;
+        }
+
+        var submitted = false;
+        var request = $.post(url, { data: dataObject });
+        evaluationSubmitRequest = request;
+
+        request.done(function () {
+            submitted = true;
+        });
+
+        // Register cleanup before UI callbacks so an unexpected response or
+        // message error cannot leave a failed submission locked.
+        request.always(function () {
+            evaluationSubmitRequest = null;
+
+            if (!submitted) {
+                evaluationSubmissionInProgress = false;
+                setEvaluationSubmitBusy($button, false);
+            }
+        });
+
+        request.done(function () {
             if ($button.hasClass('js-next')) {
                 var $current = $(".current");
                 var $next = $current.nextAll('.visible:first');
@@ -74,7 +137,11 @@ $(function(){
                     document.location = $link.attr('href');
                 }
             }
-        }).fail(function (rs) {
+
+            MapasCulturais.Messages.success(labels.saveMessage);
+        });
+
+        request.fail(function (rs) {
             if (rs.responseJSON && rs.responseJSON.error) {
                 if (rs.responseJSON.data instanceof Array) {
                     rs.responseJSON.data.forEach(function (msg) {
@@ -85,18 +152,78 @@ $(function(){
                 }
             }
         });
+    }
+
+    $(window).scroll(function(){
+        var top = parseInt($header.css('top'));
+        /* $formContainer.css('margin-top', top);
+        $list.css('margin-top', top); */
+    });
+
+    $formContainer.find('.js-evaluation-submit').on('click', function (e) {
+        e.preventDefault();
+
+        if (evaluationSubmissionInProgress) {
+            return;
+        }
+
+        var $button = $(this);
+        var url = MapasCulturais.createUrl('registration', 'saveEvaluation', {
+            '0': MapasCulturais.request.id,
+            'status': 'evaluated'
+        });
+
+        var isValid = true;
+        $('.bonus-select').each(function () {
+            var $select = $(this);
+            var value = $select.val();
+
+            if (value==="?") {
+                isValid = false;
+                MapasCulturais.Messages.error('Por favor, selecione uma opção válida em todos os campos de bônus.');
+                $select.focus();
+                return false;
+            }
+
+        });
+
+        if (!isValid) {
+            return;
+        }
+
+        // Freeze the exact data the evaluator confirmed before disabling the
+        // controls and, if needed, waiting for an in-flight autosave.
+        var dataObject = getEvaluationData();
+
+        clearTimeout(__onChangeTimeout);
+        __onChangeTimeout = null;
+        autoSaveQueued = false;
+        evaluationSubmissionInProgress = true;
+        setEvaluationSubmitBusy($button, true);
+
+        // An autosave already accepted by the server cannot be safely aborted.
+        // Wait for it so the final write is always the last request.
+        if (autoSaveRequest) {
+            autoSaveCompletionCallbacks.push(function () {
+                submitEvaluation($button, url, dataObject);
+            });
+        } else {
+            submitEvaluation($button, url, dataObject);
+        }
     });
 
 
-    var __onChangeTimeout;
     $(".autosave").on('keyup change', function() {
         clearTimeout(__onChangeTimeout);
+
+        if (evaluationSubmissionInProgress) {
+            __onChangeTimeout = null;
+            return;
+        }
+
         __onChangeTimeout = setTimeout(function(){
-            var data = $form.serialize();
-            var url = MapasCulturais.createUrl('registration', 'saveEvaluation', {'0': MapasCulturais.request.id, 'status': 'evaluated'});
-            $.post(url, data, function(r){
-                MapasCulturais.Messages.success(labels.saveMessage);
-            });
+            __onChangeTimeout = null;
+            autoSaveEvaluation();
         },15000);
 
     });

--- a/src/protected/application/themes/BaseV1/layouts/parts/singles/registration--sidebar--right.php
+++ b/src/protected/application/themes/BaseV1/layouts/parts/singles/registration--sidebar--right.php
@@ -77,6 +77,7 @@ $canSubmit =
                 <hr>
                 <div style="text-align: right;">
                     <button 
+                        type="button"
                         class="btn btn-primary js-evaluation-submit js-next <?= $canSubmit ? '' : 'is-disabled' ?>"
                         id="btn-submit-evaluation"
                         <?php if (!$canSubmit): ?>

--- a/src/protected/db-updates.php
+++ b/src/protected/db-updates.php
@@ -2108,4 +2108,168 @@ $$
         );
     },
 
+    'deduplicate opinions and enforce submission uniqueness' => function () use ($conn) {
+        $app = App::i();
+        $registrationEvaluationType = \MapasCulturais\Entities\RegistrationEvaluation::class;
+        $accountabilityOpinionType = \Diligence\Entities\Opinion::class;
+        $evaluationPartitionUser = "CASE
+            WHEN EXISTS (
+                SELECT 1
+                FROM registration registration
+                JOIN opportunity_meta accountability_meta
+                  ON accountability_meta.object_id = registration.opportunity_id
+                 AND accountability_meta.key = 'isAccountabilityPhase'
+                 AND accountability_meta.value = '1'
+                WHERE registration.id = evaluation.registration_id
+            ) THEN NULL
+            ELSE evaluation.user_id
+        END";
+
+        $conn->beginTransaction();
+
+        try {
+            // New writers acquire the shared form before any row lock. Taking
+            // the exclusive form here lets in-flight writers finish, then keeps
+            // new ones from holding a registration while waiting for our table
+            // locks. Table-first ordering also lets pre-deployment writers drain
+            // without a registration/table deadlock.
+            $conn->executeQuery(
+                "SELECT pg_advisory_xact_lock(hashtext('MapasCulturais:opinion-submission:migration'))"
+            );
+            $conn->executeQuery(
+                'LOCK TABLE registration_evaluation, accountability_opinion IN SHARE ROW EXCLUSIVE MODE'
+            );
+
+            // Re-read after acquiring the table lock so the reconsolidation list
+            // includes any write that committed while the migration was waiting.
+            $affectedRows = $conn->fetchAll(
+                "SELECT evaluation.registration_id AS id
+                 FROM registration_evaluation evaluation
+                 GROUP BY evaluation.registration_id, {$evaluationPartitionUser}
+                 HAVING COUNT(*) > 1
+                 ORDER BY evaluation.registration_id"
+            );
+            $affectedRegistrationIds = array_values(array_unique(array_map(
+                'intval',
+                array_column($affectedRows, 'id')
+            )));
+
+            if ($affectedRegistrationIds) {
+                $ids = implode(',', $affectedRegistrationIds);
+                $conn->executeQuery(
+                    "SELECT id FROM registration WHERE id IN ({$ids}) ORDER BY id FOR UPDATE"
+                );
+            }
+
+            // Keep the submitted/published row with the greatest status. Within
+            // the same status, keep the most recently updated row. Evaluation
+            // phases normally keep one row per user; accountability phases have
+            // a single technical opinion for the whole registration. All
+            // revisions and accountability chats are reassigned first.
+            $conn->executeQuery(
+                "CREATE TEMPORARY TABLE duplicate_registration_evaluation_map
+                 ON COMMIT DROP AS
+                 SELECT id AS duplicate_id, canonical_id
+                 FROM (
+                     SELECT
+                         id,
+                         FIRST_VALUE(id) OVER (
+                             PARTITION BY registration_id, {$evaluationPartitionUser}
+                             ORDER BY
+                                 status DESC NULLS LAST,
+                                 COALESCE(update_timestamp, create_timestamp) DESC NULLS LAST,
+                                 id DESC
+                         ) AS canonical_id
+                     FROM registration_evaluation evaluation
+                 ) ranked
+                 WHERE id <> canonical_id"
+            );
+
+            $conn->executeUpdate(
+                'UPDATE entity_revision revision
+                 SET object_id = duplicate.canonical_id
+                 FROM duplicate_registration_evaluation_map duplicate
+                 WHERE revision.object_id = duplicate.duplicate_id
+                   AND revision.object_type::varchar = ?',
+                [$registrationEvaluationType]
+            );
+
+            $conn->executeUpdate(
+                'UPDATE chat_thread thread
+                 SET object_id = duplicate.canonical_id
+                 FROM duplicate_registration_evaluation_map duplicate
+                 WHERE thread.object_id = duplicate.duplicate_id
+                   AND thread.object_type::varchar = ?',
+                [$registrationEvaluationType]
+            );
+
+            $conn->executeUpdate(
+                'DELETE FROM registration_evaluation evaluation
+                 USING duplicate_registration_evaluation_map duplicate
+                 WHERE evaluation.id = duplicate.duplicate_id'
+            );
+
+            $conn->executeQuery(
+                'CREATE TEMPORARY TABLE duplicate_accountability_opinion_map
+                 ON COMMIT DROP AS
+                 SELECT id AS duplicate_id, canonical_id
+                 FROM (
+                     SELECT
+                         id,
+                         FIRST_VALUE(id) OVER (
+                             PARTITION BY registration_id
+                             ORDER BY
+                                 status DESC NULLS LAST,
+                                 COALESCE(update_timestamp, create_timestamp) DESC NULLS LAST,
+                                 id DESC
+                         ) AS canonical_id
+                     FROM accountability_opinion
+                 ) ranked
+                 WHERE id <> canonical_id'
+            );
+
+            $conn->executeUpdate(
+                'UPDATE entity_revision revision
+                 SET object_id = duplicate.canonical_id
+                 FROM duplicate_accountability_opinion_map duplicate
+                 WHERE revision.object_id = duplicate.duplicate_id
+                   AND revision.object_type::varchar = ?',
+                [$accountabilityOpinionType]
+            );
+
+            $conn->executeUpdate(
+                'DELETE FROM accountability_opinion opinion
+                 USING duplicate_accountability_opinion_map duplicate
+                 WHERE opinion.id = duplicate.duplicate_id'
+            );
+
+            $conn->executeQuery(
+                'CREATE UNIQUE INDEX IF NOT EXISTS registration_evaluation_registration_user_unique
+                 ON registration_evaluation (registration_id, user_id)'
+            );
+            $conn->executeQuery(
+                'CREATE UNIQUE INDEX IF NOT EXISTS accountability_opinion_registration_unique
+                 ON accountability_opinion (registration_id)'
+            );
+
+            // Duplicate evaluations may have changed averages or consolidated
+            // statuses. Use each configured evaluation method to restore the
+            // materialized result before making the cleanup visible.
+            foreach ($affectedRegistrationIds as $registrationId) {
+                $registration = $app->repo('Registration')->find($registrationId);
+                if ($registration) {
+                    $registration->consolidateResult(true);
+                }
+            }
+
+            $conn->commit();
+        } catch (\Throwable $exception) {
+            if ($conn->isTransactionActive()) {
+                $conn->rollBack();
+            }
+
+            throw $exception;
+        }
+    },
+
 ] + $updates ;

--- a/tests/DuplicateOpinionSubmissionTest.php
+++ b/tests/DuplicateOpinionSubmissionTest.php
@@ -1,0 +1,1054 @@
+<?php
+
+require_once __DIR__ . '/bootstrap.php';
+// Work around the legacy test autoloader not registering module entity subclasses.
+require_once __DIR__ . '/../src/protected/application/lib/modules/Diligence/Entities/DiligenceFile.php';
+
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+
+class DuplicateOpinionSubmissionTest extends MapasCulturais_TestCase
+{
+    public function testRegistrationEvaluationIsUniquePerRegistrationAndUser()
+    {
+        $connection = $this->app->em->getConnection();
+        $registration = $this->createRegistrationRow();
+        $userId = $connection->fetchColumn('SELECT id FROM usr ORDER BY id LIMIT 1');
+
+        $this->assertNotFalse($userId, 'The test database must contain a user');
+
+        $parameters = [
+            $registration['registration_id'],
+            $userId,
+            '{}',
+        ];
+
+        $connection->executeUpdate(
+            "INSERT INTO registration_evaluation
+                (id, registration_id, user_id, evaluation_data, status, create_timestamp)
+             VALUES
+                (nextval('registration_evaluation_id_seq'), ?, ?, ?, 0, NOW())",
+            $parameters
+        );
+
+        $this->expectException(UniqueConstraintViolationException::class);
+
+        $connection->executeUpdate(
+            "INSERT INTO registration_evaluation
+                (id, registration_id, user_id, evaluation_data, status, create_timestamp)
+             VALUES
+                (nextval('registration_evaluation_id_seq'), ?, ?, ?, 0, NOW())",
+            $parameters
+        );
+    }
+
+    public function testOpinionIsUniquePerRegistration()
+    {
+        $connection = $this->app->em->getConnection();
+        $registration = $this->createRegistrationRow();
+
+        $parameters = [
+            'Regression test opinion',
+            $registration['registration_id'],
+            $registration['agent_id'],
+        ];
+
+        $connection->executeUpdate(
+            "INSERT INTO accountability_opinion
+                (id, opinion, status, registration_id, agent_id, create_timestamp)
+             VALUES
+                (nextval('accountability_opinion_id_seq'), ?, 0, ?, ?, NOW())",
+            $parameters
+        );
+
+        $this->expectException(UniqueConstraintViolationException::class);
+
+        $connection->executeUpdate(
+            "INSERT INTO accountability_opinion
+                (id, opinion, status, registration_id, agent_id, create_timestamp)
+             VALUES
+                (nextval('accountability_opinion_id_seq'), ?, 0, ?, ?, NOW())",
+            $parameters
+        );
+    }
+
+    public function testConcurrentEvaluationInitializationIsSerialized()
+    {
+        $this->requireSubprocessSupport();
+
+        $database = $this->createIndependentConnection();
+        $fixture = $this->createCommittedRegistrationFixture($database);
+        $tag = 'evaluation_race_' . bin2hex(random_bytes(6));
+        $blocker = $this->createIndependentConnection();
+        $workers = [];
+
+        try {
+            $blocker->beginTransaction();
+            $statement = $blocker->prepare('SELECT id FROM registration WHERE id = ? FOR UPDATE');
+            $statement->execute([$fixture['registration_id']]);
+
+            $workerCode = $this->createEvaluationWorkerCode(
+                $fixture['registration_id'],
+                $fixture['user_id'],
+                $tag
+            );
+            $workers[] = $this->startWorker($workerCode);
+            $workers[] = $this->startWorker($workerCode);
+
+            $this->waitForWorkersToBlock($database, $tag, 2, $workers);
+            $blocker->commit();
+
+            foreach ($workers as &$worker) {
+                $this->assertWorkerSucceeded($worker);
+            }
+            unset($worker);
+
+            $statement = $database->prepare(
+                'SELECT COUNT(*), COUNT(DISTINCT id)
+                 FROM registration_evaluation
+                 WHERE registration_id = ? AND user_id = ?'
+            );
+            $statement->execute([
+                $fixture['registration_id'],
+                $fixture['user_id'],
+            ]);
+
+            $this->assertSame(
+                [1, 1],
+                $statement->fetch(\PDO::FETCH_NUM),
+                'Both requests must return successfully while creating only one evaluation'
+            );
+        } finally {
+            if ($blocker->inTransaction()) {
+                $blocker->rollBack();
+            }
+            $this->terminateWorkers($workers);
+            $this->deleteCommittedRegistrationFixture($database, $fixture);
+        }
+    }
+
+    public function testConcurrentOpinionCreationIsSerialized()
+    {
+        $this->requireSubprocessSupport();
+
+        $database = $this->createIndependentConnection();
+        $fixture = $this->createCommittedRegistrationFixture($database);
+        $tag = 'opinion_race_' . bin2hex(random_bytes(6));
+        $blocker = $this->createIndependentConnection();
+        $workers = [];
+
+        try {
+            $blocker->beginTransaction();
+            $statement = $blocker->prepare('SELECT id FROM registration WHERE id = ? FOR UPDATE');
+            $statement->execute([$fixture['registration_id']]);
+
+            $workerCode = $this->createOpinionWorkerCode(
+                $fixture['registration_id'],
+                $fixture['user_id'],
+                $tag
+            );
+            $workers[] = $this->startWorker($workerCode);
+            $workers[] = $this->startWorker($workerCode);
+
+            $this->waitForWorkersToBlock($database, $tag, 2, $workers);
+            $blocker->commit();
+
+            foreach ($workers as &$worker) {
+                $this->assertWorkerSucceeded($worker);
+            }
+            unset($worker);
+
+            $statement = $database->prepare(
+                'SELECT COUNT(*), COUNT(DISTINCT id)
+                 FROM accountability_opinion
+                 WHERE registration_id = ?'
+            );
+            $statement->execute([$fixture['registration_id']]);
+
+            $this->assertSame(
+                [1, 1],
+                $statement->fetch(\PDO::FETCH_NUM),
+                'Both requests must return successfully while creating only one opinion'
+            );
+        } finally {
+            if ($blocker->inTransaction()) {
+                $blocker->rollBack();
+            }
+            $this->terminateWorkers($workers);
+            $this->deleteCommittedRegistrationFixture($database, $fixture);
+            @unlink('/tmp/mapasculturais-tests-authenticated-user.id');
+        }
+    }
+
+    public function testSentEvaluationNoOpStillRejectsUnauthorizedUser()
+    {
+        $connection = $this->app->em->getConnection();
+        $fixture = $this->createCurrentTransactionRegistrationFixture();
+        $evaluationOwner = $this->getUser('normal', 0);
+        $unauthorizedUser = $this->getUser('normal', 1);
+        $confidentialData = ['status' => 10, 'confidential' => 'owner-only'];
+
+        $connection->executeUpdate(
+            "INSERT INTO registration_evaluation
+                (id, registration_id, user_id, evaluation_data, status, create_timestamp)
+             VALUES
+                (nextval('registration_evaluation_id_seq'), ?, ?, ?, ?, NOW())",
+            [
+                $fixture['registration_id'],
+                $evaluationOwner->id,
+                json_encode($confidentialData),
+                \MapasCulturais\Entities\RegistrationEvaluation::STATUS_SENT,
+            ]
+        );
+
+        $registration = $this->app->repo('Registration')->find($fixture['registration_id']);
+        $returnedEvaluation = null;
+        $exception = null;
+
+        $this->app->auth->logout();
+        $this->app->auth->setAuthenticatedUser($unauthorizedUser);
+
+        try {
+            $returnedEvaluation = $registration->saveUserEvaluation(
+                $confidentialData,
+                $evaluationOwner,
+                \MapasCulturais\Entities\RegistrationEvaluation::STATUS_SENT
+            );
+        } catch (\Throwable $caught) {
+            $exception = $caught;
+        } finally {
+            $this->app->auth->logout();
+        }
+
+        $this->assertInstanceOf(
+            \MapasCulturais\Exceptions\PermissionDenied::class,
+            $exception,
+            'A sent-evaluation no-op must perform authorization before returning the entity'
+        );
+        $this->assertNull(
+            $returnedEvaluation,
+            'An unauthorized caller must never receive an evaluation containing evaluationData'
+        );
+    }
+
+    public function testAccountabilityEvaluationIsGlobalAcrossUsers()
+    {
+        $connection = $this->app->em->getConnection();
+        $fixture = $this->createCurrentTransactionRegistrationFixture(true);
+        $firstUser = $this->getUser('normal', 0);
+        $secondUser = $this->getUser('normal', 1);
+        $registration = $this->app->repo('Registration')->find($fixture['registration_id']);
+
+        $this->app->disableAccessControl();
+
+        try {
+            $firstEvaluation = $registration->saveUserEvaluation(
+                ['result' => 10, 'obs' => 'First accountability opinion'],
+                $firstUser,
+                \MapasCulturais\Entities\RegistrationEvaluation::STATUS_EVALUATED
+            );
+            $secondEvaluation = $registration->saveUserEvaluation(
+                ['result' => 8, 'obs' => 'Second accountability opinion'],
+                $secondUser,
+                \MapasCulturais\Entities\RegistrationEvaluation::STATUS_EVALUATED
+            );
+        } finally {
+            $this->app->enableAccessControl();
+        }
+
+        $this->assertSame(
+            $firstEvaluation->id,
+            $secondEvaluation->id,
+            'Accountability has one technical evaluation for the registration, not one per user'
+        );
+        $this->assertSame(
+            1,
+            (int) $connection->fetchColumn(
+                'SELECT COUNT(*) FROM registration_evaluation WHERE registration_id = ?',
+                [$fixture['registration_id']]
+            )
+        );
+    }
+
+    public function testSaveUserEvaluationAndLegacySaveDoNotDeadlock()
+    {
+        $this->requireSubprocessSupport();
+
+        $database = $this->createIndependentConnection();
+        $fixture = $this->createCommittedRegistrationFixture($database);
+        $evaluationId = $this->createCommittedEvaluation($database, $fixture);
+        $legacyTag = 'legacy_eval_race_' . bin2hex(random_bytes(6));
+        $saveTag = 'save_eval_race_' . bin2hex(random_bytes(6));
+        $blocker = $this->createIndependentConnection();
+        $workers = [];
+
+        try {
+            $blocker->beginTransaction();
+            $statement = $blocker->prepare(
+                'SELECT id FROM registration_evaluation WHERE id = ? FOR UPDATE'
+            );
+            $statement->execute([$evaluationId]);
+
+            $workers[] = $this->startWorker($this->createLegacyEvaluationSaveWorkerCode(
+                $evaluationId,
+                $legacyTag
+            ));
+            $this->waitForTaggedWorkersToWait($database, [$legacyTag], $workers);
+
+            $workers[] = $this->startWorker($this->createSaveUserEvaluationWorkerCode(
+                $fixture['registration_id'],
+                $fixture['user_id'],
+                $saveTag
+            ));
+            $this->waitForTaggedWorkersToWait(
+                $database,
+                [$legacyTag, $saveTag],
+                $workers
+            );
+
+            $blocker->commit();
+
+            foreach ($workers as &$worker) {
+                $this->assertWorkerSucceeded($worker);
+            }
+            unset($worker);
+
+            $statement = $database->prepare(
+                'SELECT COUNT(*) FROM registration_evaluation WHERE registration_id = ?'
+            );
+            $statement->execute([$fixture['registration_id']]);
+            $this->assertSame(1, (int) $statement->fetchColumn());
+        } finally {
+            if ($blocker->inTransaction()) {
+                $blocker->rollBack();
+            }
+            $this->terminateWorkers($workers);
+            $this->deleteCommittedRegistrationFixture($database, $fixture);
+        }
+    }
+
+    public function testDeleteAndSaveUserEvaluationDoNotDeadlockAndRecreateEvaluation()
+    {
+        $this->requireSubprocessSupport();
+
+        $database = $this->createIndependentConnection();
+        $fixture = $this->createCommittedRegistrationFixture($database);
+        $evaluationId = $this->createCommittedEvaluation($database, $fixture);
+        $fixture['removed_evaluation_ids'] = [$evaluationId];
+        $deleteTag = 'delete_eval_race_' . bin2hex(random_bytes(6));
+        $saveTag = 'save_after_delete_race_' . bin2hex(random_bytes(6));
+        $blocker = $this->createIndependentConnection();
+        $workers = [];
+
+        try {
+            $blocker->beginTransaction();
+            $statement = $blocker->prepare(
+                'SELECT id FROM registration_evaluation WHERE id = ? FOR UPDATE'
+            );
+            $statement->execute([$evaluationId]);
+
+            $workers[] = $this->startWorker($this->createEvaluationDeleteWorkerCode(
+                $evaluationId,
+                $deleteTag
+            ));
+            $this->waitForTaggedWorkersToWait($database, [$deleteTag], $workers);
+
+            $workers[] = $this->startWorker($this->createSaveUserEvaluationWorkerCode(
+                $fixture['registration_id'],
+                $fixture['user_id'],
+                $saveTag
+            ));
+            $this->waitForTaggedWorkersToWait(
+                $database,
+                [$deleteTag, $saveTag],
+                $workers
+            );
+
+            $blocker->commit();
+
+            foreach ($workers as &$worker) {
+                $this->assertWorkerSucceeded($worker);
+            }
+            unset($worker);
+
+            $statement = $database->prepare(
+                "SELECT id, user_id, status, evaluation_data::json->>'status' AS data_status
+                 FROM registration_evaluation
+                 WHERE registration_id = ?"
+            );
+            $statement->execute([$fixture['registration_id']]);
+            $evaluations = $statement->fetchAll();
+
+            $this->assertCount(
+                1,
+                $evaluations,
+                'The save queued after delete must recreate exactly one evaluation'
+            );
+            $this->assertNotSame($evaluationId, (int) $evaluations[0]['id']);
+            $this->assertSame($fixture['user_id'], (int) $evaluations[0]['user_id']);
+            $this->assertSame(
+                \MapasCulturais\Entities\RegistrationEvaluation::STATUS_EVALUATED,
+                (int) $evaluations[0]['status']
+            );
+            $this->assertSame('8', $evaluations[0]['data_status']);
+        } finally {
+            if ($blocker->inTransaction()) {
+                $blocker->rollBack();
+            }
+            $this->terminateWorkers($workers);
+            $this->deleteCommittedRegistrationFixture($database, $fixture);
+        }
+    }
+
+    private function createRegistrationRow()
+    {
+        $connection = $this->app->em->getConnection();
+        $project = $connection->fetchAssoc(
+            'SELECT id AS project_id, agent_id
+             FROM project
+             WHERE agent_id IS NOT NULL
+             ORDER BY id
+             LIMIT 1'
+        );
+
+        $this->assertNotFalse($project, 'The test database must contain a project with an owner');
+
+        $opportunityId = $connection->fetchColumn(
+            "INSERT INTO opportunity
+                (agent_id, type, name, short_description, published_registrations,
+                 create_timestamp, status, object_type, object_id)
+             VALUES
+                (?, 1, 'Duplicate submission regression test', 'Regression test', FALSE,
+                 NOW(), 1, 'MapasCulturais\\Entities\\Project', ?)
+             RETURNING id",
+            [
+                $project['agent_id'],
+                $project['project_id'],
+            ]
+        );
+
+        $registrationId = $connection->fetchColumn(
+            "INSERT INTO registration
+                (opportunity_id, agent_id, create_timestamp, status, agents_data)
+             VALUES
+                (?, ?, NOW(), 0, '{}')
+             RETURNING id",
+            [
+                $opportunityId,
+                $project['agent_id'],
+            ]
+        );
+
+        return [
+            'registration_id' => $registrationId,
+            'agent_id' => $project['agent_id'],
+        ];
+    }
+
+    private function createCurrentTransactionRegistrationFixture($accountability = false)
+    {
+        $connection = $this->app->em->getConnection();
+        $project = $connection->fetchAssoc(
+            'SELECT id AS project_id, agent_id
+             FROM project
+             WHERE agent_id IS NOT NULL
+             ORDER BY id
+             LIMIT 1'
+        );
+
+        if (!$project) {
+            throw new \RuntimeException('The test database must contain a project with an owner');
+        }
+
+        $opportunityId = $connection->fetchColumn(
+            "INSERT INTO opportunity
+                (agent_id, type, name, short_description, published_registrations,
+                 create_timestamp, status, object_type, object_id)
+             VALUES
+                (?, 1, 'Evaluation regression test', 'Regression test', FALSE,
+                 NOW(), 1, 'MapasCulturais\\Entities\\Project', ?)
+             RETURNING id",
+            [$project['agent_id'], $project['project_id']]
+        );
+
+        $configurationId = $connection->fetchColumn(
+            'INSERT INTO evaluation_method_configuration (opportunity_id, type)
+             VALUES (?, ?)
+             RETURNING id',
+            [$opportunityId, $accountability ? 'accountability' : 'simple']
+        );
+
+        if ($accountability) {
+            $connection->executeUpdate(
+                "INSERT INTO opportunity_meta (object_id, key, value)
+                 VALUES (?, 'isAccountabilityPhase', '1')",
+                [$opportunityId]
+            );
+        }
+
+        $registrationId = $connection->fetchColumn(
+            "INSERT INTO registration
+                (opportunity_id, agent_id, create_timestamp, status, agents_data)
+             VALUES
+                (?, ?, NOW(), 0, '{}')
+             RETURNING id",
+            [$opportunityId, $project['agent_id']]
+        );
+
+        return [
+            'registration_id' => (int) $registrationId,
+            'opportunity_id' => (int) $opportunityId,
+            'configuration_id' => (int) $configurationId,
+            'agent_id' => (int) $project['agent_id'],
+        ];
+    }
+
+    private function requireSubprocessSupport()
+    {
+        if (!function_exists('proc_open')) {
+            $this->markTestSkipped('proc_open is required for the concurrent request regression test');
+        }
+    }
+
+    private function createIndependentConnection()
+    {
+        $parameters = $this->app->em->getConnection()->getParams();
+        $host = $parameters['host'] ?? 'localhost';
+        $port = $parameters['port'] ?? 5432;
+        $database = $parameters['dbname'];
+        $dsn = "pgsql:host={$host};port={$port};dbname={$database}";
+
+        return new \PDO(
+            $dsn,
+            $parameters['user'],
+            $parameters['password'],
+            [
+                \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+                \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+            ]
+        );
+    }
+
+    private function createCommittedRegistrationFixture(\PDO $database)
+    {
+        $database->beginTransaction();
+
+        try {
+            $project = $database->query(
+                'SELECT id AS project_id, agent_id
+                 FROM project
+                 WHERE agent_id IS NOT NULL
+                 ORDER BY id
+                 LIMIT 1'
+            )->fetch();
+            $userId = $database->query('SELECT id FROM usr ORDER BY id LIMIT 1')->fetchColumn();
+
+            if (!$project || !$userId) {
+                throw new \RuntimeException('The test database needs a project owner and a user');
+            }
+
+            $statement = $database->prepare(
+                "INSERT INTO opportunity
+                    (agent_id, type, name, short_description, published_registrations,
+                     create_timestamp, status, object_type, object_id)
+                 VALUES
+                    (?, 1, 'Concurrent submission regression test', 'Regression test', FALSE,
+                     NOW(), 1, 'MapasCulturais\\Entities\\Project', ?)
+                 RETURNING id"
+            );
+            $statement->execute([
+                $project['agent_id'],
+                $project['project_id'],
+            ]);
+            $opportunityId = $statement->fetchColumn();
+
+            $statement = $database->prepare(
+                "INSERT INTO evaluation_method_configuration (opportunity_id, type)
+                 VALUES (?, 'simple')
+                 RETURNING id"
+            );
+            $statement->execute([$opportunityId]);
+            $configurationId = $statement->fetchColumn();
+
+            $statement = $database->prepare(
+                "INSERT INTO registration
+                    (opportunity_id, agent_id, create_timestamp, status, agents_data)
+                 VALUES
+                    (?, ?, NOW(), 0, '{}')
+                 RETURNING id"
+            );
+            $statement->execute([
+                $opportunityId,
+                $project['agent_id'],
+            ]);
+            $registrationId = $statement->fetchColumn();
+
+            $database->commit();
+
+            return [
+                'registration_id' => (int) $registrationId,
+                'opportunity_id' => (int) $opportunityId,
+                'configuration_id' => (int) $configurationId,
+                'agent_id' => (int) $project['agent_id'],
+                'user_id' => (int) $userId,
+            ];
+        } catch (\Throwable $exception) {
+            if ($database->inTransaction()) {
+                $database->rollBack();
+            }
+            throw $exception;
+        }
+    }
+
+    private function createCommittedEvaluation(\PDO $database, array $fixture)
+    {
+        $statement = $database->prepare(
+            "INSERT INTO registration_evaluation
+                (id, registration_id, user_id, evaluation_data, status, create_timestamp)
+             VALUES
+                (nextval('registration_evaluation_id_seq'), ?, ?, ?, 0, NOW())
+             RETURNING id"
+        );
+        $statement->execute([
+            $fixture['registration_id'],
+            $fixture['user_id'],
+            json_encode(['status' => 10]),
+        ]);
+
+        return (int) $statement->fetchColumn();
+    }
+
+    private function createEvaluationWorkerCode($registrationId, $userId, $tag)
+    {
+        return sprintf(
+            <<<'PHP'
+try {
+    require %s;
+    // The legacy test bootstrap does not autoload module entity subclasses.
+    require_once %s;
+    $app = \MapasCulturais\App::i();
+    $connection = $app->em->getConnection();
+    $connection->executeQuery('SET application_name TO ' . $connection->quote(%s));
+    $connection->executeQuery("SET lock_timeout TO '10s'");
+    $app->disableAccessControl();
+    $registration = $app->repo('Registration')->find(%d);
+    $user = $app->repo('User')->find(%d);
+    $evaluation = $registration->initializeUserEvaluation($user);
+    if (!$evaluation || !$evaluation->id) {
+        throw new \RuntimeException('The evaluation was not initialized');
+    }
+    fwrite(STDOUT, (string) $evaluation->id);
+} catch (\Throwable $exception) {
+    fwrite(STDERR, get_class($exception) . ': ' . $exception->getMessage());
+    exit(1);
+}
+PHP
+            ,
+            var_export(__DIR__ . '/bootstrap.php', true),
+            var_export(__DIR__ . '/../src/protected/application/lib/modules/Diligence/Entities/DiligenceFile.php', true),
+            var_export($tag, true),
+            $registrationId,
+            $userId
+        );
+    }
+
+    private function createOpinionWorkerCode($registrationId, $userId, $tag)
+    {
+        return sprintf(
+            <<<'PHP'
+try {
+    require %s;
+    // The legacy test bootstrap does not autoload these Diligence module symbols.
+    require_once %s;
+    require_once %s;
+    $app = \MapasCulturais\App::i();
+    $connection = $app->em->getConnection();
+    $connection->executeQuery('SET application_name TO ' . $connection->quote(%s));
+    $connection->executeQuery("SET lock_timeout TO '10s'");
+    $user = $app->repo('User')->find(%d);
+    $app->auth->setAuthenticatedUser($user);
+    $app->disableAccessControl();
+    $controller = $app->controller('diligence');
+    if (!$controller) {
+        throw new \RuntimeException('The diligence controller is not registered');
+    }
+    $method = new \ReflectionMethod($controller, 'createOrUpdateOpinion');
+    $method->setAccessible(true);
+    $method->invoke($controller, [
+        'registrationId' => %d,
+        'opinion' => 'Concurrent published opinion',
+    ], true);
+    $opinion = $app->repo(\Diligence\Entities\Opinion::class)->findOneBy([
+        'registration' => %d,
+    ]);
+    if (!$opinion || !$opinion->id) {
+        throw new \RuntimeException('The opinion was not created');
+    }
+    fwrite(STDOUT, (string) $opinion->id);
+} catch (\Throwable $exception) {
+    fwrite(STDERR, get_class($exception) . ': ' . $exception->getMessage());
+    exit(1);
+}
+PHP
+            ,
+            var_export(__DIR__ . '/bootstrap.php', true),
+            var_export(__DIR__ . '/../src/protected/application/lib/modules/Diligence/Entities/DiligenceFile.php', true),
+            var_export(__DIR__ . '/../src/protected/application/lib/modules/Diligence/Traits/DiligenceSingle.php', true),
+            var_export($tag, true),
+            $userId,
+            $registrationId,
+            $registrationId
+        );
+    }
+
+    private function createLegacyEvaluationSaveWorkerCode($evaluationId, $tag)
+    {
+        return sprintf(
+            <<<'PHP'
+try {
+    require %s;
+    require_once %s;
+    $app = \MapasCulturais\App::i();
+    $connection = $app->em->getConnection();
+    $connection->executeQuery('SET application_name TO ' . $connection->quote(%s));
+    $connection->executeQuery("SET lock_timeout TO '10s'");
+    $app->disableAccessControl();
+    $evaluation = $app->repo('RegistrationEvaluation')->find(%d);
+    if (!$evaluation) {
+        throw new \RuntimeException('The legacy evaluation does not exist');
+    }
+    $evaluation->evaluationData = ['status' => 3];
+    $evaluation->status = \MapasCulturais\Entities\RegistrationEvaluation::STATUS_EVALUATED;
+    $evaluation->save(true);
+    fwrite(STDOUT, (string) $evaluation->id);
+} catch (\Throwable $exception) {
+    fwrite(STDERR, get_class($exception) . ': ' . $exception->getMessage());
+    exit(1);
+}
+PHP
+            ,
+            var_export(__DIR__ . '/bootstrap.php', true),
+            var_export(__DIR__ . '/../src/protected/application/lib/modules/Diligence/Entities/DiligenceFile.php', true),
+            var_export($tag, true),
+            $evaluationId
+        );
+    }
+
+    private function createEvaluationDeleteWorkerCode($evaluationId, $tag)
+    {
+        return sprintf(
+            <<<'PHP'
+try {
+    require %s;
+    require_once %s;
+    $app = \MapasCulturais\App::i();
+    $connection = $app->em->getConnection();
+    $connection->executeQuery('SET application_name TO ' . $connection->quote(%s));
+    $connection->executeQuery("SET lock_timeout TO '10s'");
+    $app->disableAccessControl();
+    $evaluation = $app->repo('RegistrationEvaluation')->find(%d);
+    if (!$evaluation) {
+        throw new \RuntimeException('The evaluation to delete does not exist');
+    }
+    $deletedId = $evaluation->id;
+    $evaluation->delete(true);
+    fwrite(STDOUT, (string) $deletedId);
+} catch (\Throwable $exception) {
+    fwrite(STDERR, get_class($exception) . ': ' . $exception->getMessage());
+    exit(1);
+}
+PHP
+            ,
+            var_export(__DIR__ . '/bootstrap.php', true),
+            var_export(__DIR__ . '/../src/protected/application/lib/modules/Diligence/Entities/DiligenceFile.php', true),
+            var_export($tag, true),
+            $evaluationId
+        );
+    }
+
+    private function createSaveUserEvaluationWorkerCode($registrationId, $userId, $tag)
+    {
+        return sprintf(
+            <<<'PHP'
+try {
+    require %s;
+    require_once %s;
+    $app = \MapasCulturais\App::i();
+    $connection = $app->em->getConnection();
+    $connection->executeQuery('SET application_name TO ' . $connection->quote(%s));
+    $connection->executeQuery("SET lock_timeout TO '10s'");
+    $app->disableAccessControl();
+    $registration = $app->repo('Registration')->find(%d);
+    $user = $app->repo('User')->find(%d);
+    $evaluation = $registration->saveUserEvaluation(
+        ['status' => 8],
+        $user,
+        \MapasCulturais\Entities\RegistrationEvaluation::STATUS_EVALUATED
+    );
+    if (!$evaluation || !$evaluation->id) {
+        throw new \RuntimeException('saveUserEvaluation did not return an evaluation');
+    }
+    fwrite(STDOUT, (string) $evaluation->id);
+} catch (\Throwable $exception) {
+    fwrite(STDERR, get_class($exception) . ': ' . $exception->getMessage());
+    exit(1);
+}
+PHP
+            ,
+            var_export(__DIR__ . '/bootstrap.php', true),
+            var_export(__DIR__ . '/../src/protected/application/lib/modules/Diligence/Entities/DiligenceFile.php', true),
+            var_export($tag, true),
+            $registrationId,
+            $userId
+        );
+    }
+
+    private function startWorker($code)
+    {
+        $stdout = tempnam(sys_get_temp_dir(), 'submission-race-out-');
+        $stderr = tempnam(sys_get_temp_dir(), 'submission-race-err-');
+        $command = escapeshellarg(PHP_BINARY)
+            . ' -d display_errors=1 -d log_errors=0 -d error_reporting=1 -r '
+            . escapeshellarg($code);
+        $process = proc_open(
+            $command,
+            [
+                0 => ['file', '/dev/null', 'r'],
+                1 => ['file', $stdout, 'w'],
+                2 => ['file', $stderr, 'w'],
+            ],
+            $pipes
+        );
+
+        if (!is_resource($process)) {
+            @unlink($stdout);
+            @unlink($stderr);
+            throw new \RuntimeException('Unable to start concurrent test worker');
+        }
+
+        return [
+            'process' => $process,
+            'stdout' => $stdout,
+            'stderr' => $stderr,
+            'finished' => false,
+        ];
+    }
+
+    private function waitForWorkersToBlock(\PDO $database, $tag, $expectedWorkers, array $workers)
+    {
+        $statement = $database->prepare(
+            "SELECT COUNT(*)
+             FROM pg_stat_activity
+             WHERE application_name = ?
+               AND wait_event_type = 'Lock'
+               AND query LIKE '%SELECT id FROM registration WHERE id = %FOR UPDATE%'"
+        );
+        // Cold application boot can be slow in CI; lock_timeout still bounds
+        // each worker once it reaches the critical section.
+        $deadline = microtime(true) + 45;
+
+        do {
+            $statement->execute([$tag]);
+            if ((int) $statement->fetchColumn() === $expectedWorkers) {
+                return;
+            }
+            usleep(100000);
+        } while (microtime(true) < $deadline);
+
+        $activityStatement = $database->prepare(
+            "SELECT pid, state, wait_event_type, wait_event, query
+             FROM pg_stat_activity
+             WHERE application_name = ?"
+        );
+        $activityStatement->execute([$tag]);
+        $activity = $activityStatement->fetchAll();
+        $workerDiagnostics = [];
+
+        foreach ($workers as $worker) {
+            $status = proc_get_status($worker['process']);
+            $workerDiagnostics[] = [
+                'running' => $status['running'],
+                'exitcode' => $status['exitcode'],
+                'stdout' => file_get_contents($worker['stdout']),
+                'stderr' => file_get_contents($worker['stderr']),
+            ];
+        }
+
+        throw new \RuntimeException(sprintf(
+            '%d workers did not reach the registration lock. activity=%s workers=%s',
+            $expectedWorkers,
+            json_encode($activity),
+            json_encode($workerDiagnostics)
+        ));
+    }
+
+    private function waitForTaggedWorkersToWait(\PDO $database, array $tags, array $workers)
+    {
+        $placeholders = implode(', ', array_fill(0, count($tags), '?'));
+        $statement = $database->prepare(
+            "SELECT application_name, COUNT(*)
+             FROM pg_stat_activity
+             WHERE application_name IN ({$placeholders})
+               AND wait_event_type = 'Lock'
+             GROUP BY application_name"
+        );
+        $deadline = microtime(true) + 45;
+
+        do {
+            $statement->execute($tags);
+            $waitingTags = $statement->fetchAll(\PDO::FETCH_KEY_PAIR);
+            $allWaiting = true;
+
+            foreach ($tags as $tag) {
+                if (empty($waitingTags[$tag])) {
+                    $allWaiting = false;
+                    break;
+                }
+            }
+
+            if ($allWaiting) {
+                return;
+            }
+
+            usleep(100000);
+        } while (microtime(true) < $deadline);
+
+        $activityStatement = $database->prepare(
+            "SELECT application_name, pid, state, wait_event_type, wait_event, query
+             FROM pg_stat_activity
+             WHERE application_name IN ({$placeholders})"
+        );
+        $activityStatement->execute($tags);
+        $workerDiagnostics = [];
+
+        foreach ($workers as $worker) {
+            $status = proc_get_status($worker['process']);
+            $workerDiagnostics[] = [
+                'running' => $status['running'],
+                'exitcode' => $status['exitcode'],
+                'stdout' => file_get_contents($worker['stdout']),
+                'stderr' => file_get_contents($worker['stderr']),
+            ];
+        }
+
+        throw new \RuntimeException(sprintf(
+            'Workers did not reach the expected locks. activity=%s workers=%s',
+            json_encode($activityStatement->fetchAll()),
+            json_encode($workerDiagnostics)
+        ));
+    }
+
+    private function assertWorkerSucceeded(array &$worker)
+    {
+        $deadline = microtime(true) + 15;
+        $status = proc_get_status($worker['process']);
+
+        while ($status['running'] && microtime(true) < $deadline) {
+            usleep(100000);
+            $status = proc_get_status($worker['process']);
+        }
+
+        if ($status['running']) {
+            proc_terminate($worker['process']);
+            $this->fail('A concurrent submission worker timed out');
+        }
+
+        $closeStatus = proc_close($worker['process']);
+        $worker['finished'] = true;
+        $exitCode = $closeStatus >= 0 ? $closeStatus : $status['exitcode'];
+        $stdout = file_get_contents($worker['stdout']);
+        $stderr = file_get_contents($worker['stderr']);
+        @unlink($worker['stdout']);
+        @unlink($worker['stderr']);
+
+        $this->assertSame(
+            0,
+            $exitCode,
+            "Concurrent worker failed. stdout: {$stdout}; stderr: {$stderr}"
+        );
+        $this->assertNotSame('', trim($stdout), 'Concurrent worker must return the persisted entity id');
+    }
+
+    private function terminateWorkers(array &$workers)
+    {
+        foreach ($workers as &$worker) {
+            if (!empty($worker['finished'])) {
+                continue;
+            }
+
+            if (isset($worker['process']) && is_resource($worker['process'])) {
+                $status = proc_get_status($worker['process']);
+                if ($status['running']) {
+                    proc_terminate($worker['process']);
+                }
+                proc_close($worker['process']);
+            }
+
+            if (isset($worker['stdout'])) {
+                @unlink($worker['stdout']);
+            }
+            if (isset($worker['stderr'])) {
+                @unlink($worker['stderr']);
+            }
+        }
+        unset($worker);
+    }
+
+    private function deleteCommittedRegistrationFixture(\PDO $database, array $fixture)
+    {
+        $database->beginTransaction();
+
+        try {
+            $removedEvaluationIds = array_values(array_filter(array_map(
+                'intval',
+                $fixture['removed_evaluation_ids'] ?? []
+            )));
+
+            if ($removedEvaluationIds) {
+                $placeholders = implode(', ', array_fill(0, count($removedEvaluationIds), '?'));
+                $statement = $database->prepare(
+                    "DELETE FROM entity_revision
+                     WHERE object_type::varchar = 'MapasCulturais\\Entities\\RegistrationEvaluation'
+                       AND object_id IN ({$placeholders})"
+                );
+                $statement->execute($removedEvaluationIds);
+            }
+
+            $statement = $database->prepare(
+                "DELETE FROM entity_revision
+                 WHERE (object_type::varchar = 'MapasCulturais\\Entities\\RegistrationEvaluation'
+                        AND object_id IN (
+                            SELECT id FROM registration_evaluation WHERE registration_id = ?
+                        ))
+                    OR (object_type::varchar = 'Diligence\\Entities\\Opinion'
+                        AND object_id IN (
+                            SELECT id FROM accountability_opinion WHERE registration_id = ?
+                        ))
+                    OR (object_type::varchar = 'MapasCulturais\\Entities\\Registration'
+                        AND object_id = ?)"
+            );
+            $statement->execute([
+                $fixture['registration_id'],
+                $fixture['registration_id'],
+                $fixture['registration_id'],
+            ]);
+
+            $statement = $database->prepare('DELETE FROM accountability_opinion WHERE registration_id = ?');
+            $statement->execute([$fixture['registration_id']]);
+            $statement = $database->prepare('DELETE FROM registration_evaluation WHERE registration_id = ?');
+            $statement->execute([$fixture['registration_id']]);
+            $statement = $database->prepare('DELETE FROM registration WHERE id = ?');
+            $statement->execute([$fixture['registration_id']]);
+            $statement = $database->prepare('DELETE FROM evaluation_method_configuration WHERE id = ?');
+            $statement->execute([$fixture['configuration_id']]);
+            $statement = $database->prepare('DELETE FROM opportunity WHERE id = ?');
+            $statement->execute([$fixture['opportunity_id']]);
+
+            $database->commit();
+        } catch (\Throwable $exception) {
+            if ($database->inTransaction()) {
+                $database->rollBack();
+            }
+            throw $exception;
+        }
+    }
+}


### PR DESCRIPTION
### ✅ Descrição do propósito desse Pull Request
Corrigido na branch fix/duplicate-opinion-submission, criada diretamente da develop.
A causa não era apenas o frontend:
Cliques duplos e autosaves podiam gerar requisições simultâneas ou tardias.
Backend fazia “buscar e depois criar” sem operação atômica.
Não existiam restrições únicas no banco.
Fluxos legados de envio/reabertura/remoção usavam ordem de locks diferente, permitindo deadlock.
A correção inclui:
Mutex, snapshot do formulário, cancelamento/serialização de autosaves e botões type="button" nos três frontends: [avaliação genérica (line 62)](/home/gabriel/mapasculturais-v5/src/protected/application/themes/BaseV1/assets/js/evaluations.js:62), [prestação de contas (line 179)](/home/gabriel/mapasculturais-v5/src/protected/application/lib/modules/OpportunityAccountability/assets/js/ng.evaluationMethod.accountability.js:179) e [Diligence (line 428)](/home/gabriel/mapasculturais-v5/src/protected/application/lib/modules/Diligence/assets/js/diligence/diligence.js:428).
Lock transacional, idempotência, autorização antes dos no-ops e parecer único por prestação de contas em [Registration.php (line 1378)](/home/gabriel/mapasculturais-v5/src/protected/application/lib/MapasCulturais/Entities/Registration.php:1378).
Ordem uniforme de locks também para envio, reabertura e remoção em [RegistrationEvaluation.php (line 106)](/home/gabriel/mapasculturais-v5/src/protected/application/lib/MapasCulturais/Entities/RegistrationEvaluation.php:106).
Migração que remove duplicatas existentes, preserva o parecer mais avançado, remapeia revisões/chats e cria índices únicos em [db-updates.php (line 2111)](/home/gabriel/mapasculturais-v5/src/protected/db-updates.php:2111).
Validação:
8 testes, 33 asserções, passando 3 vezes consecutivas.
Concorrência real com processos separados, incluindo criação, publicação, save legado e delete.
Migração validada com 3 avaliações → 1 e 2 pareceres → 1, sem perder revisões ou conversas.
PHP 7.2 lint, JavaScript syntax check e whitespace check aprovados.
Testes em [DuplicateOpinionSubmissionTest.php (line 9)](/home/gabriel/mapasculturais-v5/tests/DuplicateOpinionSubmissionTest.php:9).
As mudanças estão prontas, mas ainda não foram commitadas.

### 🧭 Referência a Issue


### ❓ O que foi feito para atingir isso?

---
### 🏃‍♀️ Tipo de mudança
Marque as opções relevantes:
- [ ] Bug fix (correção de bug)
- [ ] Nova feature (mudança não retrocompatível que adiciona funcionalidade)
- [ ] Mudança de breaking (correção ou feature que faria com que a funcionalidade existente não funcionasse como esperado)
- [ ] Documentação (somente mudanças ou atualizações na documentação)
---

### 🕵️ Como foi testado?
- [ ] Critério de aceitação
- [ ] Testes de software (TDD, BDD, UNITÁRIO, INTEGRAÇÃO, E2E)
---

**Checklist: ✔️**
- [ ] Meu código segue as diretrizes do projeto
- [ ] Eu fiz um code review com minha equipe
- [ ] Eu comentei meu código, especialmente em áreas de difícil entendimento
- [ ] Eu atualizei a documentação correspondente
- [ ] Testes novos e existentes passaram localmente com minhas alterações
---

**Observação:**
